### PR TITLE
Add App-wide Middleware Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-Note: Experiment to see how much of Express JS I can copy. Yes, I know fiber exists, but I want to build this solely with net/http.
+# Go Express
+
+This is currently an experiment to see how much of `express.js`, an HTTP server library for `Node.js` apps, I can copy. Yes, I know `go-fiber` exists, but I want to build this solely with net/http.
+
+## Sample Code
+
+Check out `example/main.go`, but in summary, this should feel much like Express.
+
+```
+app := express.New()
+
+app.Use(express.Cors(
+  express.Config{
+    "origin": "*",
+  },
+))
+
+app.Get("/", func(w http.ResponseWriter, r *http.Request) {
+  w.Header().Set("Content-Type", "application/json")
+  json.NewEncoder(w).Encode(express.GenericResponse{"message": "GET hello world"})
+})
+
+app.Post("/", func(w http.ResponseWriter, r *http.Request) {
+  w.Header().Set("Content-Type", "application/json")
+  json.NewEncoder(w).Encode(express.GenericResponse{"message": "POST hello world"})
+})
+
+app.Listen(5200)
+```

--- a/example/main.go
+++ b/example/main.go
@@ -8,17 +8,24 @@ import (
 	"github.com/jsphbtst/go-express"
 )
 
-func SampleCustomMiddleware(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/redirect" && r.Method == http.MethodGet {
-		log.Println("REDIRECT URL IDK MAN")
+func SampleCustomMiddleware(config express.Config) express.Handler {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" && r.Method == http.MethodGet {
+			log.Println("REDIRECT URL IDK MAN")
+		}
 	}
 }
 
 func main() {
 	app := express.New()
-	app.Use(express.Cors)
-	app.Use(express.LogPathAccess)
-	app.Use(SampleCustomMiddleware)
+
+	app.Use(express.Cors(
+		express.Config{
+			"origin": "*",
+		},
+	))
+	app.Use(express.LogPathAccess(nil))
+	app.Use(SampleCustomMiddleware(nil))
 
 	app.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/example/main.go
+++ b/example/main.go
@@ -8,16 +8,16 @@ import (
 	"github.com/jsphbtst/go-express"
 )
 
-func LogGetRedirectMiddleware(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.Path
-	if path == "/redirect" && r.Method == http.MethodGet {
+func SampleCustomMiddleware(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/redirect" && r.Method == http.MethodGet {
 		log.Println("REDIRECT URL IDK MAN")
 	}
 }
 
 func main() {
 	app := express.New()
-	app.Use(LogGetRedirectMiddleware)
+	app.Use(express.LogPathAccess)
+	app.Use(SampleCustomMiddleware)
 
 	app.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/example/main.go
+++ b/example/main.go
@@ -16,6 +16,7 @@ func SampleCustomMiddleware(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	app := express.New()
+	app.Use(express.Cors)
 	app.Use(express.LogPathAccess)
 	app.Use(SampleCustomMiddleware)
 

--- a/example/main.go
+++ b/example/main.go
@@ -2,13 +2,22 @@ package main
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/jsphbtst/go-express"
 )
 
+func LogGetRedirectMiddleware(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	if path == "/redirect" && r.Method == http.MethodGet {
+		log.Println("REDIRECT URL IDK MAN")
+	}
+}
+
 func main() {
 	app := express.New()
+	app.Use(LogGetRedirectMiddleware)
 
 	app.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/express.go
+++ b/express.go
@@ -7,26 +7,6 @@ import (
 	"net/http"
 )
 
-type Server struct {
-	*http.Server
-}
-
-type GenericResponse map[string]string
-
-// just so there's semantic difference for the reader
-type Handler = func(http.ResponseWriter, *http.Request)
-
-type Route map[string]Handler
-
-type Express struct {
-	routes       StringSet
-	middlewares  []Handler
-	getRoutes    StringSet
-	getHandlers  Route
-	postRoutes   StringSet
-	postHandlers Route
-}
-
 func response404Handler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	// note to self: this goes strictly AFTER else it does not
@@ -46,8 +26,8 @@ func New() *Express {
 	}
 }
 
-func (app *Express) Use(middleware Handler) {
-	app.middlewares = append(app.middlewares, middleware)
+func (app *Express) Use(handler Handler) {
+	app.middlewares = append(app.middlewares, handler)
 }
 
 func (app *Express) Get(pathname string, handler Handler) {

--- a/express.go
+++ b/express.go
@@ -69,8 +69,6 @@ func (app *Express) Listen(port int) {
 		}
 
 		currentPath := r.URL.Path
-		log.Printf("%s `%s`\n", r.Method, currentPath)
-
 		isPathExists := app.routes.Contains(currentPath)
 		if !isPathExists {
 			response404Handler(w, r)

--- a/middlewares.go
+++ b/middlewares.go
@@ -5,12 +5,20 @@ import (
 	"net/http"
 )
 
-func LogPathAccess(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.Path
-	log.Printf("%s `%s`\n", r.Method, path)
+func LogPathAccess(config Config) Handler {
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		log.Printf("%s `%s`\n", r.Method, path)
+	}
 }
 
-// TODO: allow for origin to be changed lol
-func Cors(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+func Cors(config Config) Handler {
+	return func(w http.ResponseWriter, r *http.Request) {
+		origin, ok := config["origin"]
+		if !ok {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+		} else {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+		}
+	}
 }

--- a/middlewares.go
+++ b/middlewares.go
@@ -9,3 +9,8 @@ func LogPathAccess(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
 	log.Printf("%s `%s`\n", r.Method, path)
 }
+
+// TODO: allow for origin to be changed lol
+func Cors(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+}

--- a/middlewares.go
+++ b/middlewares.go
@@ -1,0 +1,11 @@
+package express
+
+import (
+	"log"
+	"net/http"
+)
+
+func LogPathAccess(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	log.Printf("%s `%s`\n", r.Method, path)
+}

--- a/set.go
+++ b/set.go
@@ -1,3 +1,4 @@
+// TODO: use self-balancing tree as a set
 package express
 
 type StringSet []string

--- a/types.go
+++ b/types.go
@@ -1,0 +1,25 @@
+package express
+
+import "net/http"
+
+type Config map[string]string
+
+// just so there's semantic difference for the reader
+type Handler = func(http.ResponseWriter, *http.Request)
+
+type Server struct {
+	*http.Server
+}
+
+type GenericResponse = map[string]string
+
+type Route = map[string]Handler
+
+type Express struct {
+	routes       StringSet
+	middlewares  []Handler
+	getRoutes    StringSet
+	getHandlers  Route
+	postRoutes   StringSet
+	postHandlers Route
+}


### PR DESCRIPTION
# Description

This PR adds the capability to add app-wide middleware.

## Code Snippet

```

...

func SampleCustomMiddleware(config express.Config) express.Handler {
  return func(w http.ResponseWriter, r *http.Request) {
    if r.URL.Path == "/redirect" && r.Method == http.MethodGet {
      log.Println("REDIRECT URL IDK MAN")
    }
  }
}

app := express.New()

app.Use(express.Cors(
  express.Config{
    "origin": "*",
  },
))
```

